### PR TITLE
Puppet 4 updates

### DIFF
--- a/manifests/commands.pp
+++ b/manifests/commands.pp
@@ -5,7 +5,7 @@ class nagios::commands (
   $define_command      = [],
 ) inherits nagios::params {
   file { $configfile_commands:
-    require => package[$package_name],
+    require => Package[$package_name],
     content => template($template_commands),
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,11 +23,11 @@ class nagios (
 ) inherits ::nagios::params {
   package { $package_name: ensure => installed }
   file { $configfile_nagios:
-    require => package[$package_name],
+    require => Package[$package_name],
     content => template($template_nagios),
   }
   file { $configfile_contacts:
-    require => package[$package_name],
+    require => Package[$package_name],
     content => template($template_contacts),
   }
   if $::osfamily == 'RedHat' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@ class nagios (
   }
   if $::osfamily == 'RedHat' {
     service { 'nagios':
-      require => package[$package_name],
+      require => Package[$package_name],
       enable  => true,
     }
   }

--- a/manifests/nrpe.pp
+++ b/manifests/nrpe.pp
@@ -8,12 +8,12 @@ class nagios::nrpe (
 ) inherits ::nagios::params {
   package { $package_name_nrpe: ensure => installed }
   file { $configfile_nrpe:
-    require => package[$package_name_nrpe],
+    require => Package[$package_name_nrpe],
     content => template($template_nrpe),
   }
   if $::osfamily == 'RedHat' {
     service { 'nrpe':
-      require => package[$package_name_nrpe],
+      require => Package[$package_name_nrpe],
       enable  => true,
     }
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -11,7 +11,7 @@ define nagios::server (
     ensure => directory,
   }
   file { "${configdir_server}/${configfile_server}":
-    require => package[$package_name],
+    require => Package[$package_name],
     content => template($template_server),
   }
 }


### PR DESCRIPTION
changed 'require => package' calls to 'require => Package', to suit Puppet 4 rules